### PR TITLE
RNTL-9614 Adding support of shared subscriptions to Aedes

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+registry = http://npm.internal:4873
 package-lock=false

--- a/lib/client.js
+++ b/lib/client.js
@@ -101,7 +101,9 @@ function Client (broker, conn, req) {
   }
 
   this.deliver0 = function deliverQoS0 (_packet, cb) {
-    _packet.topic = that.broker.persistence.restoreOriginalTopicFromSharedOne(_packet.topic)
+    if (that.broker.sharedTopicsEnabled) {
+      _packet.topic = that.broker.persistence.restoreOriginalTopicFromSharedOne(_packet.topic)
+    }
     const toForward = getToForwardPacket(_packet)
 
     if (toForward) {
@@ -121,7 +123,9 @@ function Client (broker, conn, req) {
   }
 
   this.deliverQoS = function deliverQoS (_packet, cb) {
-    _packet.topic = that.broker.persistence.restoreOriginalTopicFromSharedOne(_packet.topic)
+    if (that.broker.sharedTopicsEnabled) {
+      _packet.topic = that.broker.persistence.restoreOriginalTopicFromSharedOne(_packet.topic)
+    }
 
     // downgrade to qos0 if requested by publish
     if (_packet.qos === 0) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -101,6 +101,7 @@ function Client (broker, conn, req) {
   }
 
   this.deliver0 = function deliverQoS0 (_packet, cb) {
+    _packet.topic = that.broker.persistence.restoreOriginalTopicFromSharedOne(_packet.topic)
     const toForward = getToForwardPacket(_packet)
 
     if (toForward) {
@@ -120,6 +121,8 @@ function Client (broker, conn, req) {
   }
 
   this.deliverQoS = function deliverQoS (_packet, cb) {
+    _packet.topic = that.broker.persistence.restoreOriginalTopicFromSharedOne(_packet.topic)
+
     // downgrade to qos0 if requested by publish
     if (_packet.qos === 0) {
       that.deliver0(_packet, cb)

--- a/lib/handlers/subscribe.js
+++ b/lib/handlers/subscribe.js
@@ -3,7 +3,7 @@
 const fastfall = require('fastfall')
 const Packet = require('aedes-packet')
 const { through } = require('../utils')
-const { validateTopic, $SYS_PREFIX } = require('../utils')
+const { validateTopic, $SYS_PREFIX, sharedTopic } = require('../utils')
 const write = require('../write')
 
 const subscribeTopicActions = fastfall([
@@ -135,7 +135,7 @@ function addSubs (sub, done) {
 
   const client = this.client
   const broker = client.broker
-  const topic = sub.topic
+  let topic = sub.topic
   const qos = sub.qos
   const rh = this.rh
   const rap = this.rap
@@ -150,20 +150,34 @@ function addSubs (sub, done) {
     deliverFunc(_packet, cb)
   }
 
-  // [MQTT-4.7.2-1]
-  if (isStartsWithWildcard(topic)) {
+  // MQTT-5 shared subscription support
+  if (broker.sharedTopicsEnabled && topic.startsWith('$share/')) {
+    const parsed = sharedTopic(topic)
+    return broker.persistence.storeSharedSubscription(parsed.topic, parsed.group, client.id, (err, newClientTopic) => {
+      if (err) {
+        done(err)
+      }
+      // change topic for client specific
+      topic = newClientTopic
+      finish()
+    })
+  } else if (isStartsWithWildcard(topic)) { // [MQTT-4.7.2-1]
     func = blockDollarSignTopics(func)
   }
 
-  if (!client.subscriptions[topic]) {
-    client.subscriptions[topic] = new Subscription(qos, func, rh, rap, nl)
-    broker.subscribe(topic, func, done)
-  } else if (client.subscriptions[topic].qos !== qos || client.subscriptions[topic].rh !== rh || client.subscriptions[topic].rap !== rap || client.subscriptions[topic].nl !== nl) {
-    broker.unsubscribe(topic, client.subscriptions[topic].func)
-    client.subscriptions[topic] = new Subscription(qos, func, rh, rap, nl)
-    broker.subscribe(topic, func, done)
-  } else {
-    done()
+  return finish()
+
+  function finish () {
+    if (!client.subscriptions[topic]) {
+      client.subscriptions[topic] = new Subscription(qos, func, rh, rap, nl)
+      broker.subscribe(topic, func, done)
+    } else if (client.subscriptions[topic].qos !== qos || client.subscriptions[topic].rh !== rh || client.subscriptions[topic].rap !== rap || client.subscriptions[topic].nl !== nl) {
+      broker.unsubscribe(topic, client.subscriptions[topic].func)
+      client.subscriptions[topic] = new Subscription(qos, func, rh, rap, nl)
+      broker.subscribe(topic, func, done)
+    } else {
+      done()
+    }
   }
 }
 

--- a/lib/handlers/unsubscribe.js
+++ b/lib/handlers/unsubscribe.js
@@ -57,15 +57,32 @@ function doUnsubscribe (sub, done) {
   const broker = client.broker
   const s = client.subscriptions[sub]
 
-  if (s) {
-    const func = s.func
-    delete client.subscriptions[sub]
-    broker.unsubscribe(
-      sub,
-      func,
-      done)
+  if (broker.sharedTopicsEnabled) {
+    const parsed = broker.persistence.parseSharedTopic(sub)
+    if (parsed) {
+      const clientId = parsed.client_id ?? client.id
+      return broker.persistence.removeSharedSubscription(parsed.topic, parsed.group, clientId, (err) => {
+        if (err) {
+          done(err)
+        } else {
+          finish()
+        }
+      })
+    } else {
+      finish()
+    }
   } else {
-    done()
+    finish()
+  }
+
+  function finish () {
+    if (s) {
+      const func = s.func
+      delete client.subscriptions[sub]
+      broker.unsubscribe(sub, func, done)
+    } else {
+      done()
+    }
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,9 +46,21 @@ function bulk (fn) {
   })
 }
 
+function sharedTopic (topic) {
+  if (!topic || !topic.startsWith('$share/')) return null
+
+  const group = topic.substring(7, topic.indexOf('/', 7))
+
+  return {
+    group,
+    topic: topic.substring(8 + group.length)
+  }
+}
+
 module.exports = {
   validateTopic,
   through,
   bulk,
-  $SYS_PREFIX: '$SYS/'
+  $SYS_PREFIX: '$SYS/',
+  sharedTopic
 }

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
   },
   "dependencies": {
     "aedes-packet": "^3.0.0",
-    "aedes-persistence": "^9.1.2",
+    "aedes-persistence": "git+ssh://git@github.com:bolteu/aedes-persistence.git#feature/RNTL-9614-shared-subscription-support",
     "end-of-stream": "^1.4.4",
     "fastfall": "^1.5.1",
     "fastparallel": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Stream-based MQTT broker",
   "main": "aedes.js",
   "types": "aedes.d.ts",
+  "publishConfig": {
+    "registry": "http://npm.internal:4873"
+  },
   "scripts": {
     "lint": "npm run lint:standard && npm run lint:typescript && npm run lint:markdown",
     "lint:fix": "standard --fix && eslint -c types/.eslintrc.json --fix aedes.d.ts types/**/*.ts test/types/**/*.test-d.ts",
@@ -16,24 +19,7 @@
     "test:typescript": "tsd",
     "unit": "tap -J test/*.js",
     "unit:report": "tap -J test/*.js --cov --coverage-report=html --coverage-report=cobertura | tee out.tap",
-    "license-checker": "license-checker --production --onlyAllow=\"MIT;ISC;BSD-3-Clause;BSD-2-Clause\"",
-    "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
-  },
-  "release-it": {
-    "github": {
-      "release": true
-    },
-    "git": {
-      "tagName": "v${version}"
-    },
-    "hooks": {
-      "before:init": [
-        "npm run test:ci"
-      ]
-    },
-    "npm": {
-      "publish": true
-    }
+    "license-checker": "license-checker --production --onlyAllow=\"MIT;ISC;BSD-3-Clause;BSD-2-Clause\""
   },
   "pre-commit": [
     "test"
@@ -49,7 +35,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/moscajs/aedes.git"
+    "url": "git+https://github.com/bolteu/aedes.git"
   },
   "keywords": [
     "mqtt",
@@ -90,9 +76,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/moscajs/aedes/issues"
+    "url": "https://github.com/bolteu/aedes/issues"
   },
-  "homepage": "https://github.com/moscajs/aedes#readme",
+  "homepage": "https://github.com/bolteu/aedes#readme",
   "engines": {
     "node": ">=14"
   },
@@ -109,7 +95,6 @@
     "mqtt-connection": "^4.1.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
-    "release-it": "^15.2.0",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
     "tap": "^16.3.0",
@@ -118,8 +103,8 @@
     "websocket-stream": "^5.5.2"
   },
   "dependencies": {
-    "aedes-packet": "^3.0.0",
-    "aedes-persistence": "git+ssh://git@github.com:bolteu/aedes-persistence.git#feature/RNTL-9614-shared-subscription-support",
+    "aedes-packet": "3.0.1",
+    "aedes-persistence": "9.1.4",
     "end-of-stream": "^1.4.4",
     "fastfall": "^1.5.1",
     "fastparallel": "^2.4.1",

--- a/test/shared-flow.js
+++ b/test/shared-flow.js
@@ -1,0 +1,158 @@
+const { test } = require('tap')
+const { connect, setup, subscribe } = require('./helper')
+const aedes = require('../aedes')
+
+test('subscribe a single shared topic QoS 0', function (t) {
+  t.plan(4)
+
+  const broker = new aedes.Server({ sharedTopicsEnabled: true })
+  const s = connect(setup(broker))
+  t.teardown(s.broker.close.bind(s.broker))
+
+  const expected = {
+    cmd: 'publish',
+    topic: 'topic',
+    payload: Buffer.from('world'),
+    dup: false,
+    length: 12,
+    qos: 0,
+    retain: false
+  }
+
+  subscribe(t, s, '$share/someGroup/topic', 0, function () {
+    s.outStream.once('data', function (packet) {
+      t.same(packet, expected, 'packet matches')
+    })
+
+    s.broker.publish({
+      cmd: 'publish',
+      topic: 'topic',
+      payload: 'world'
+    })
+  })
+})
+
+test('subscribe 2 clients to shared topic QoS 0', function (t) {
+  t.plan(8)
+
+  const broker = new aedes.Server({ sharedTopicsEnabled: true })
+  const c1 = connect(setup(broker))
+  t.teardown(c1.broker.close.bind(c1.broker))
+
+  const expected = {
+    cmd: 'publish',
+    topic: 'hello',
+    payload: Buffer.from('world'),
+    dup: false,
+    length: 12,
+    qos: 0,
+    retain: false
+  }
+
+  subscribe(t, c1, '$share/group1/hello', 0, function () {
+    c1.outStream.once('data', function (packet) {
+      t.same(packet, expected, 'packet matches c1')
+    })
+
+    const c2 = connect(setup(broker))
+    t.teardown(c2.broker.close.bind(c2.broker))
+    subscribe(t, c2, '$share/group2/hello', 0, function () {
+      c2.outStream.once('data', function (packet) {
+        t.same(packet, expected, 'packet matches c2')
+      })
+
+      c1.broker.publish({
+        cmd: 'publish',
+        topic: 'hello',
+        payload: 'world'
+      })
+    })
+  })
+})
+
+test('subscribe to shared wildcard topic QoS 0', function (t) {
+  t.plan(5)
+
+  const broker = new aedes.Server({ sharedTopicsEnabled: true })
+  const s = connect(setup(broker))
+  t.teardown(s.broker.close.bind(s.broker))
+
+  const expected = {
+    cmd: 'publish',
+    topic: 'topic/123',
+    payload: Buffer.from('world'),
+    dup: false,
+    length: 16,
+    qos: 0,
+    retain: false
+  }
+
+  subscribe(t, s, '$share/someGroup/topic/#', 0, function () {
+    s.outStream.once('data', function (packet) {
+      t.same(packet, expected, 'packet matches')
+      const expected2 = {
+        cmd: 'publish',
+        topic: 'topic/321',
+        payload: Buffer.from('world'),
+        dup: false,
+        length: 16,
+        qos: 0,
+        retain: false
+      }
+      s.outStream.once('data', function (packet) {
+        t.same(packet, expected2, 'packet matches')
+      })
+
+      s.broker.publish({
+        cmd: 'publish',
+        topic: 'topic/321',
+        payload: 'world'
+      })
+    })
+
+    s.broker.publish({
+      cmd: 'publish',
+      topic: 'topic/123',
+      payload: 'world'
+    })
+  })
+})
+
+test('unsubscribe', function (t) {
+  t.plan(5)
+
+  const broker = new aedes.Server({ sharedTopicsEnabled: true })
+  const s = connect(setup(broker))
+  t.teardown(s.broker.close.bind(s.broker))
+
+  subscribe(t, s, '$share/someGroup/topic', 0, function () {
+    s.inStream.write({
+      cmd: 'unsubscribe',
+      messageId: 43,
+      unsubscriptions: ['$share/someGroup/topic']
+    })
+
+    s.outStream.once('data', function (packet) {
+      t.same(packet, {
+        cmd: 'unsuback',
+        messageId: 43,
+        dup: false,
+        length: 2,
+        qos: 0,
+        retain: false
+      }, 'packet matches')
+
+      s.outStream.on('data', function (packet) {
+        t.fail('packet received')
+      })
+
+      s.broker.publish({
+        cmd: 'publish',
+        topic: 'topic',
+        payload: 'world'
+      }, function () {
+        t.pass('publish finished')
+      })
+    })
+  })
+})

--- a/types/instance.d.ts
+++ b/types/instance.d.ts
@@ -57,6 +57,7 @@ declare module 'aedes' {
     authorizeSubscribe?: AuthorizeSubscribeHandler
     authorizeForward?: AuthorizeForwardHandler
     published?: PublishedHandler
+    sharedTopicsEnabled?: boolean
   }
 
   export default class Aedes extends EventEmitter {
@@ -64,6 +65,7 @@ declare module 'aedes' {
     connectedClients: Readonly<number>
     closed: Readonly<boolean>
     brokers: Readonly<Brokers>
+    persistence: any
 
     constructor(option?: AedesOptions)
     handle: (stream: Connection, request: IncomingMessage) => Client


### PR DESCRIPTION
Depend on https://github.com/bolteu/aedes-persistence/pull/2

The idea is to store Client specific topic subscriptions when this client subscribes on $share/ topic, and store this client's specific topics in persistence per topic. Once someone is publishing to the topic for which we have a shared client, this publishing client on the same publish checks - do we have shared clients, and if yes - he gets a random client topic from this group - and does additionally publish on this topics, so only once client from the group will receive this publish